### PR TITLE
Fixes a bug that caused IndexOutOfBounds crash

### DIFF
--- a/FirebaseDatabaseUI/FirebaseArray.swift
+++ b/FirebaseDatabaseUI/FirebaseArray.swift
@@ -173,8 +173,8 @@ open class FirebaseArray<T : FirebaseModel>: NSObject, Collection {
             }
             
             if let index = index {
-                let insertionIndex = self.sortOrderBlock == nil ? index : self.insertionIndex(of: model)
                 self.models.remove(at: index)
+                let insertionIndex = self.sortOrderBlock == nil ? index : self.insertionIndex(of: model)
                 self.models.insert(model, at: insertionIndex)
                 self.delegate?.changed(child: model, at: index)
                 


### PR DESCRIPTION
insertionIndex must be calculated after removing the model from the array, otherwise the code will crash if the last element of a sorted array changes.