### PR TITLE
Some suggested improvements

### DIFF
--- a/FirebaseDatabaseUI/FirebaseArrayDelegate.swift
+++ b/FirebaseDatabaseUI/FirebaseArrayDelegate.swift
@@ -19,7 +19,7 @@ import FirebaseDatabase
 public protocol FirebaseArrayDelegate: class {
     
     func update(with block: (()->Void)?)
-    func initialized()
+    func initialized<T>(array: FirebaseArray<T>)
     func added<T : FirebaseModel>(child: T, at index: Int)
     func changed<T : FirebaseModel>(child: T, at index: Int)
     func removed<T : FirebaseModel>(child: T, at index: Int)
@@ -32,7 +32,7 @@ public protocol FirebaseArrayDelegate: class {
 public extension FirebaseArrayDelegate {
     
     func update(with block: (()->Void)?) {}
-    func initialized() {}
+    func initialized<T>(array: FirebaseArray<T>) {}
     func added<T : FirebaseModel>(child: T, at index: Int) {}
     func changed<T : FirebaseModel>(child: T, at index: Int) {}
     func removed<T : FirebaseModel>(child: T, at index: Int) {}
@@ -41,3 +41,4 @@ public extension FirebaseArrayDelegate {
     func cancelled(with error: Error) {}
     
 }
+

--- a/FirebaseDatabaseUI/FirebaseDataSource.swift
+++ b/FirebaseDatabaseUI/FirebaseDataSource.swift
@@ -20,15 +20,19 @@ open class FirebaseDataSource<T: FirebaseModel>: NSObject, FirebaseArrayDelegate
     
     open var array: FirebaseArray<T>
     open var cancelBlock: ((Error)->Void)?
+    open var delegate: FirebaseArrayDelegate?
     
     lazy var sections = [String : [T]]()
     lazy var sectionNames = [String]()
     
     public init(array: FirebaseArray<T>) {
         self.array = array
+        
         super.init()
         
+        self.delegate = array.delegate
         self.array.delegate = self
+        
     }
     
     // MARK: - API methods
@@ -44,7 +48,7 @@ open class FirebaseDataSource<T: FirebaseModel>: NSObject, FirebaseArrayDelegate
         return nil
     }
     
-    open func ref(for indexPath: IndexPath) -> FIRDatabaseReference? {
+    open func ref(for indexPath: IndexPath) -> DatabaseReference? {
         if indexPath.row < self.array.count {
             return self.array.ref(for: indexPath.row)
         }
@@ -58,7 +62,7 @@ open class FirebaseDataSource<T: FirebaseModel>: NSObject, FirebaseArrayDelegate
     // MARK: - FirebaseArrayDelegate methods
     
     open func update(with block: (() -> Void)?) {}
-    open func initialized() {}
+    open func initialized<Model>(array: FirebaseArray<Model>) {}
     open func added<Model : FirebaseModel>(child: Model, at index: Int) {}
     open func changed<Model : FirebaseModel>(child: Model, at index: Int) {}
     open func removed<Model : FirebaseModel>(child: Model, at index: Int) {}

--- a/FirebaseDatabaseUI/FirebaseTableViewDataSource.swift
+++ b/FirebaseDatabaseUI/FirebaseTableViewDataSource.swift
@@ -50,72 +50,72 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
         
     // TODO: Add convenience initializers, documentation
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, filterBlock: filterBlock)
         tableView?.register(cellClass, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, prototypeReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, prototypeReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, filterBlock: filterBlock)
         self.init(array: array, reuseIdentifier: prototypeReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, filterBlock: FirebaseArray<T>.FilterBlock?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, filterBlock: filterBlock)
         let nib = UINib(nibName: nibName, bundle: nil)
         tableView?.register(nib, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, filterBlock: filterBlock)
         tableView?.register(cellClass, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, prototypeReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, prototypeReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, filterBlock: filterBlock)
         self.init(array: array, reuseIdentifier: prototypeReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, filterBlock: FirebaseArray<T>.FilterBlock?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, filterBlock: filterBlock)
         let nib = UINib(nibName: nibName, bundle: nil)
         tableView?.register(nib, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, predicate: predicate)
         tableView?.register(cellClass, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, prototypeReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, prototypeReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, predicate: predicate)
         self.init(array: array, reuseIdentifier: prototypeReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortOrderBlock: FirebaseArray<T>.SortOrderBlock?, predicate: NSPredicate?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortOrderBlock: sortOrderBlock, predicate: predicate)
         let nib = UINib(nibName: nibName, bundle: nil)
         tableView?.register(nib, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, cellClass: AnyClass?, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, predicate: predicate)
         tableView?.register(cellClass, forCellReuseIdentifier: cellReuseIdentifier)
         self.init(array: array, reuseIdentifier: cellReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, prototypeReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, prototypeReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, predicate: predicate)
         self.init(array: array, reuseIdentifier: prototypeReuseIdentifier, tableView: tableView)
     }
     
-    public convenience init(query: FIRDatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
+    public convenience init(query: DatabaseQuery, sortDescriptors: [NSSortDescriptor]?, predicate: NSPredicate?, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
         let array = FirebaseArray<T>(query: query, sortDescriptors: sortDescriptors, predicate: predicate)
         let nib = UINib(nibName: nibName, bundle: nil)
         tableView?.register(nib, forCellReuseIdentifier: cellReuseIdentifier)
@@ -127,6 +127,14 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
         super.init(array: array)
         self.tableView = tableView
     }
+
+    public init(array: FirebaseArray<T>, nibNamed nibName: String, cellReuseIdentifier: String, tableView: UITableView?) {
+        let nib = UINib(nibName: nibName, bundle: nil)
+        self.reuseIdentifier = cellReuseIdentifier
+        tableView?.register(nib, forCellReuseIdentifier: cellReuseIdentifier)
+        super.init(array: array)
+        self.tableView = tableView
+    }
     
     // MARK: - FirebaseArrayDelegate methods
     
@@ -134,10 +142,12 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
         tableView?.beginUpdates()
         block?()
         tableView?.endUpdates()
+        delegate?.update(with: block)
     }
     
-    override open func initialized() {
+    override open func initialized<M>(array: FirebaseArray<M>) {
         tableView?.reloadData()
+        delegate?.initialized(array: array)
     }
     
     override open func added<M : FirebaseModel>(child: M, at index: Int) {
@@ -178,6 +188,7 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
                 self.tableView?.insertRows(at: [indexPath], with: .automatic)
             }
         }
+        delegate?.added(child: child, at: index)
     }
     
     override open func changed<M : FirebaseModel>(child: M, at index: Int) {
@@ -203,6 +214,8 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
             let indexPath = IndexPath(row: index, section: 0)
             self.tableView?.reloadRows(at: [indexPath], with: .automatic)
         }
+        delegate?.changed(child: child, at: index)
+
     }
     
     override open func removed<M : FirebaseModel>(child: M, at index: Int) {
@@ -233,6 +246,8 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
             let indexPath = IndexPath(row: index, section: 0)
             self.tableView?.deleteRows(at: [indexPath], with: .automatic)
         }
+        delegate?.removed(child: child, at: index)
+
     }
     
     override open func moved<M : FirebaseModel>(child: M, from oldIndex: Int, to newIndex: Int) {
@@ -267,11 +282,14 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
             let oldIndexPath = IndexPath(row: oldIndex, section: 0), newIndexPath =  IndexPath(row: newIndex, section: 0)
             self.tableView?.moveRow(at: oldIndexPath, to: newIndexPath)
         }
+        delegate?.moved(child: child, from: oldIndex, to: newIndex)
+
     }
     
     override open func changedSortOrder() {
         self.updateSections()
         self.tableView?.reloadData()
+        delegate?.changedSortOrder()
     }
     
     // MARK: - UITableViewDataSource methods
@@ -361,7 +379,7 @@ open class FirebaseTableViewDataSource<T : FirebaseModel>: FirebaseDataSource<T>
      * @param indexPath The index path of the item to retrieve a reference for
      * @return A Firebase reference for the object at the given index path
      */
-    override open func ref(for indexPath: IndexPath) -> FIRDatabaseReference? {
+    override open func ref(for indexPath: IndexPath) -> DatabaseReference? {
         return self.object(at: indexPath)?.ref
     }
     


### PR DESCRIPTION
- FirebaseArrayDelegate's "initialized" function now passes the array that was initialized to the delegate

- Added a FirebaseArrayDelegate to FirebaseDataSource, as the FirebaseDataSource hijacks the delegate from the original array, thus preventing information about the events to be passed to the array's delegate

- Added support for the new delegate in FirebaseArrayDelegate to FirebaseTableViewDataSource

- Some minor cleanup (like renaming FIRDatabaseReference to DatabaseReference)

P.S. I'm not so experienced with creating pull requests yet so please let me know if I should do this differently. Thanks!